### PR TITLE
Adds brew update prior to brew install to avoid Ruby versioning error

### DIFF
--- a/building/mac/requirements.sh
+++ b/building/mac/requirements.sh
@@ -1,5 +1,6 @@
 #brew install boost pkg-config 
 brew uninstall qt5
+brew update
 brew install protobuf miniupnpc openssl qrencode berkeley-db4
 brew link berkeley-db4 --force
 # Might need these later: libevent librsvg

--- a/building/mac/requirements.sh
+++ b/building/mac/requirements.sh
@@ -1,8 +1,9 @@
 #brew install boost pkg-config 
 brew uninstall qt5
-brew install protobuf miniupnpc openssl qrencode berkeley-db4 
+brew install protobuf miniupnpc openssl qrencode berkeley-db4@4.8
+brew link berkeley-db4 --force
 # Might need these later: libevent librsvg
 curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/fdfc724dd532345f5c6cdf47dc43e99654e6a5fd/Formula/qt5.rb
-brew install ./qt5.rb
-brew link --force qt5
+HOMEBREW_NO_AUTO_UPDATE=1 brew install ./qt5.rb
+brew link qt5 --force
 


### PR DESCRIPTION
There's a ruby error that is occurring prior to berkely-db@4 being installed.  You can see it here: [Travis-CI Link](https://travis-ci.org/vergecurrency/VERGE/jobs/323505877#L1705).  Apparently this is an issue with Travis-CI that can be worked around by running brew update prior to running brew install.  [Relevant GitHub issue](https://github.com/Homebrew/brew/issues/3299)

This PR adds brew update to circumvent this issue.